### PR TITLE
getVertices() and getIndex()

### DIFF
--- a/src/main/java/com/graphapp/graphs/Algorithms.java
+++ b/src/main/java/com/graphapp/graphs/Algorithms.java
@@ -1,0 +1,21 @@
+package com.graphapp.graphs;
+
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.HashMap;
+import java.util.ArrayList;
+
+public class Algorithms {
+
+    public ArrayList<String> bfs(Graph g, Node start, Node end) {
+        return null;
+    }
+
+    public ArrayList<String> dfs(Graph g, Node start, Node end) {
+        return null;
+    }
+
+    public ArrayList<String> djikstra(Graph g, Node start, Node end) {
+        return null;
+    }
+}

--- a/src/main/java/com/graphapp/graphs/DirectedGraph.java
+++ b/src/main/java/com/graphapp/graphs/DirectedGraph.java
@@ -11,11 +11,13 @@ public class DirectedGraph implements Graph{
     private int[][] adjMatrix;
     private final ArrayList<Integer> emptyIndices;
     private final HashMap<Node, Integer> vertices;
+    private final HashMap<Integer, Node> indices;
 
     public DirectedGraph() {
         this.adjMatrix = new int[MAX_NUM_VERTICES][MAX_NUM_VERTICES];
         this.emptyIndices = new ArrayList<>();
         this.vertices = new HashMap<>();
+        this.indices = new HashMap<>();
     }
 
     @Override
@@ -24,9 +26,12 @@ public class DirectedGraph implements Graph{
             return;
         }
         if (emptyIndices.isEmpty()) {
-            vertices.put(n, getNumVertices());
+            int numVertices = getNumVertices(); // set to variable so indices and vertices match up
+            vertices.put(n, numVertices);
+            indices.put(numVertices, n);
         } else {
             vertices.put(n, emptyIndices.get(0));
+            indices.put(emptyIndices.get(0), n);
             emptyIndices.remove(0);
         }
     }
@@ -34,6 +39,7 @@ public class DirectedGraph implements Graph{
     @Override
     public void removeVertex(Node n) {
         var index = vertices.remove(n);
+        indices.remove(index);
         if (index == null) {
             return;
         }
@@ -79,6 +85,7 @@ public class DirectedGraph implements Graph{
         adjMatrix = new int[MAX_NUM_VERTICES][MAX_NUM_VERTICES];
         vertices.clear();
         emptyIndices.clear();
+        indices.clear();
     }
 
     @Override
@@ -110,6 +117,30 @@ public class DirectedGraph implements Graph{
     @Override
     public HashMap<Node, Integer> getVertices() {
         return vertices;
+    }
+
+    @Override
+    public HashMap<Integer, Node> getIndices() {
+        return indices;
+    }
+
+    @Override
+    public Node getVertex(int v) {
+        var result = indices.get(v);
+        if(result == null) {
+            return null;
+        }
+        return indices.get(v);
+    }
+
+    @Override
+    public int getIndex(Node n) {
+        var result = vertices.get(n);
+        if(result == null) {
+            return -1;
+        }
+
+        return vertices.get(n);
     }
 
     public ArrayList<Integer> getEmptyIndices() {

--- a/src/main/java/com/graphapp/graphs/DirectedGraph.java
+++ b/src/main/java/com/graphapp/graphs/DirectedGraph.java
@@ -101,6 +101,7 @@ public class DirectedGraph implements Graph{
                 if (adjMatrix[i][j] > 0) numEdges++;
             }
         }
+
         return numEdges;
     }
 

--- a/src/main/java/com/graphapp/graphs/Graph.java
+++ b/src/main/java/com/graphapp/graphs/Graph.java
@@ -16,7 +16,10 @@ interface Graph {
     int getNumEdges();
     String getNodeLabel(Node n);
     HashMap<Node, Integer> getVertices();
+    HashMap<Integer, Node> getIndices();
     int[][] getAdjMatrix();
+    Node getVertex(int v);
+    int getIndex(Node n);
 
 
 }

--- a/src/main/java/com/graphapp/graphs/Graph.java
+++ b/src/main/java/com/graphapp/graphs/Graph.java
@@ -21,5 +21,4 @@ interface Graph {
     Node getVertex(int v);
     int getIndex(Node n);
 
-
 }

--- a/src/main/java/com/graphapp/graphs/UndirectedGraph.java
+++ b/src/main/java/com/graphapp/graphs/UndirectedGraph.java
@@ -9,11 +9,13 @@ public class UndirectedGraph implements Graph {
     private final ArrayList<Integer> unusedIndices;
     private int[][] adjMatrix;
     private final HashMap<Node, Integer> vertices;
+    private final HashMap<Integer, Node> indices;
 
     public UndirectedGraph() {
         this.adjMatrix = new int[MAX_NUM_VERTICES][MAX_NUM_VERTICES];
         this.unusedIndices = new ArrayList<>();
         this.vertices = new HashMap<>();
+        this.indices = new HashMap<>();
     }
 
 
@@ -29,17 +31,21 @@ public class UndirectedGraph implements Graph {
 
         if(!unusedIndices.isEmpty()) {
             vertices.put(n, unusedIndices.get(0)); // if there are unused indices, use those
+            indices.put(unusedIndices.get(0), n);
             unusedIndices.remove(0);
         }
 
         else {
-            vertices.put(n, getNumVertices());
+            int numVertices = getNumVertices(); // set to variable so indices and vertices match up
+            vertices.put(n, numVertices);
+            indices.put(numVertices, n);
         }
     }
 
     @Override
     public void removeVertex(Node n) {
         var index = vertices.remove(n);
+        indices.remove(index);
         if(index == null) {
             return;
         }
@@ -97,6 +103,7 @@ public class UndirectedGraph implements Graph {
         adjMatrix = new int[MAX_NUM_VERTICES][MAX_NUM_VERTICES];
         unusedIndices.clear();
         vertices.clear();
+        indices.clear();
     }
 
     @Override
@@ -139,8 +146,32 @@ public class UndirectedGraph implements Graph {
     }
 
     @Override
+    public Node getVertex(int v) {
+        var result = indices.get(v);
+        if(result == null) {
+            return null;
+        }
+        return indices.get(v);
+    }
+
+    @Override
+    public int getIndex(Node n) {
+        var result = vertices.get(n);
+        if(result == null) {
+            return -1;
+        }
+
+        return vertices.get(n);
+    }
+
+    @Override
     public HashMap<Node, Integer> getVertices() {
         return vertices;
+    }
+
+    @Override
+    public HashMap<Integer, Node> getIndices() {
+        return indices;
     }
 
     public ArrayList<Integer> getUnusedIndices() {

--- a/src/main/java/com/graphapp/graphs/UndirectedGraph.java
+++ b/src/main/java/com/graphapp/graphs/UndirectedGraph.java
@@ -95,7 +95,6 @@ public class UndirectedGraph implements Graph {
     @Override
     public void removeAllEdges() {
         adjMatrix = new int[MAX_NUM_VERTICES][MAX_NUM_VERTICES];
-
     }
 
     @Override

--- a/src/test/java/com/graphapp/graphs/DirectedGraphTest.java
+++ b/src/test/java/com/graphapp/graphs/DirectedGraphTest.java
@@ -13,14 +13,19 @@ class DirectedGraphTest {
     void addVertex() {
         graph = new DirectedGraph();
 
-        graph.addVertex(new Node("1"));
+        Node n1 = new Node("1");
+        Node n2 = new Node("2");
+
+        graph.addVertex(n1);
         assertEquals(1, graph.getNumVertices());
 
-        graph.addVertex(new Node("2"));
+        graph.addVertex(n2);
         assertEquals(2, graph.getNumVertices());
 
         var vertices = graph.getVertices();
+        var indices = graph.getIndices();
         assertEquals(2, vertices.size());
+        assertEquals(n1 , graph.getVertex(graph.getIndex(n1)));
     }
 
     @Test
@@ -40,12 +45,25 @@ class DirectedGraphTest {
         graph.addEdge(n3, n1, null);
         assertEquals(4, graph.getNumVertices());
 
+        var vertices = graph.getVertices();
+        var indices = graph.getIndices();
+
+        assertEquals(n1, graph.getVertex(graph.getIndex(n1)));
+        assertEquals(n2, graph.getVertex(graph.getIndex(n2)));
+        assertEquals(n3, graph.getVertex(graph.getIndex(n3)));
+        assertEquals(n4, graph.getVertex(graph.getIndex(n4)));
+
+
         graph.removeVertex(n1);
         assertEquals(3, graph.getNumVertices());
         int[][] expected = new int[50][50];
         expected[1][2] = 1;
         int[][] actual = graph.getAdjMatrix();
         assertArrayEquals(expected, actual);
+
+        vertices = graph.getVertices();
+        indices = graph.getIndices();
+        assertNull(graph.getVertex(graph.getIndex(n1))); // not found since removed
 
         var emptyIndices = graph.getEmptyIndices();
         assertEquals(1, emptyIndices.size());
@@ -55,6 +73,12 @@ class DirectedGraphTest {
         actual = graph.getAdjMatrix();
         assertEquals(2, graph.getNumVertices());
         assertArrayEquals(expected, actual);
+
+        vertices = graph.getVertices();
+        indices = graph.getIndices();
+        assertNull(graph.getVertex(graph.getIndex(n2))); // not found since removed
+
+
     }
 
     @Test
@@ -157,6 +181,7 @@ class DirectedGraphTest {
         graph.removeAllVertices();
         assertEquals(0, graph.getVertices().size());
         assertEquals(0, graph.getNumVertices());
+        assertEquals(0, graph.getIndices().size());
 
         int[][] expected = new int[50][50];
         int[][] actual = graph.getAdjMatrix();

--- a/src/test/java/com/graphapp/graphs/DirectedGraphTest.java
+++ b/src/test/java/com/graphapp/graphs/DirectedGraphTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class DirectedGraphTest {
     private DirectedGraph graph;
 
+
     @Test
     void addVertex() {
         graph = new DirectedGraph();

--- a/src/test/java/com/graphapp/graphs/UndirectedGraphTests.java
+++ b/src/test/java/com/graphapp/graphs/UndirectedGraphTests.java
@@ -29,6 +29,7 @@ public class UndirectedGraphTests {
         assertEquals(2, vertices.size());
 
         assertEquals(n1 , graph.getVertex(graph.getIndex(n1)));
+
     }
 
     @Test

--- a/src/test/java/com/graphapp/graphs/UndirectedGraphTests.java
+++ b/src/test/java/com/graphapp/graphs/UndirectedGraphTests.java
@@ -3,6 +3,7 @@ package com.graphapp.graphs;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import java.util.Arrays;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -14,14 +15,20 @@ public class UndirectedGraphTests {
     void addVertex() {
         graph = new UndirectedGraph();
 
-        graph.addVertex(new Node("A"));
+        Node n1 = new Node("A");
+        Node n2 = new Node("B");
+
+        graph.addVertex(n1);
         assertEquals(1, graph.getNumVertices());
 
-        graph.addVertex(new Node("B"));
+        graph.addVertex(n2);
         assertEquals(2, graph.getNumVertices());
 
         var vertices = graph.getVertices();
+        var indices = graph.getIndices();
         assertEquals(2, vertices.size());
+
+        assertEquals(n1 , graph.getVertex(graph.getIndex(n1)));
     }
 
     @Test
@@ -95,6 +102,13 @@ public class UndirectedGraphTests {
         assertEquals(1, graph.getNumEdges());
         assertArrayEquals(expected, actual);
         assertEquals(1, unusedIndices.size());
+
+        var vertices = graph.getVertices();
+        var indices = graph.getIndices();
+
+        assertNull(graph.getVertex(graph.getIndex(n1))); // not found since removed
+        assertEquals(n2, graph.getVertex(graph.getIndex(n2)));
+
     }
 
     @Test
@@ -217,6 +231,7 @@ public class UndirectedGraphTests {
         assertEquals(0, graph.getNumVertices());
         assertEquals(0, graph.getNumEdges());
         assertEquals(0, graph.getVertices().size());
+        assertEquals(0, graph.getIndices().size());
 
         int[][] expected = new int[50][50];
         int[][] actual = graph.getAdjMatrix();


### PR DESCRIPTION
Added getVertices() and getIndex() methods to Graph interface, in order to get Node by index, and get index by Node--respectively. Also added necessary tests to both graph tests.